### PR TITLE
Add symbolic runtime scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lumeria"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+regex = "1"
+

--- a/core0.lore
+++ b/core0.lore
@@ -1,0 +1,11 @@
+[capsule my.test]
+
+[trigger hello.world /]
+
+[logic hello.world]
+  > log: "🌍 Hello World"
+  > emit: next.step
+[/logic hello.world]
+
+[/capsule my.test]
+

--- a/src/lumeria_loader.rs
+++ b/src/lumeria_loader.rs
@@ -1,0 +1,51 @@
+use std::fs;
+use std::path::Path;
+use regex::Regex;
+
+#[derive(Debug)]
+pub struct Capsule {
+    pub name: String,
+    pub triggers: Vec<String>,
+    pub logic: Vec<String>,
+}
+
+pub struct CapsuleLoader {
+    file: String,
+}
+
+impl CapsuleLoader {
+    pub fn new<P: AsRef<Path>>(file: P) -> Self {
+        Self { file: file.as_ref().to_string_lossy().to_string() }
+    }
+
+    pub fn load_capsules(&self) -> Vec<Capsule> {
+        let data = fs::read_to_string(&self.file)
+            .expect("Unable to read lore file");
+        let capsule_re = Regex::new(r"\[capsule\s+([^\]]+)\](?s)(.*?)\[/capsule\s+\1\]").unwrap();
+        let trigger_re = Regex::new(r"\[trigger\s+([^\s/]+)\s*/\]").unwrap();
+        let logic_re = Regex::new(r"\[logic\s+([^\]]+)\](?s)(.*?)\[/logic\s+\1\]").unwrap();
+
+        let mut capsules = Vec::new();
+        for cap in capsule_re.captures_iter(&data) {
+            let cap_name = cap.get(1).unwrap().as_str().trim().to_string();
+            let body = cap.get(2).unwrap().as_str();
+            let mut triggers = Vec::new();
+            let mut logic_blocks = Vec::new();
+            for tcap in trigger_re.captures_iter(body) {
+                triggers.push(tcap.get(1).unwrap().as_str().trim().to_string());
+            }
+            for lcap in logic_re.captures_iter(body) {
+                logic_blocks.push(lcap.get(2).unwrap().as_str().trim().to_string());
+            }
+            let capsule = Capsule {
+                name: cap_name,
+                triggers,
+                logic: logic_blocks,
+            };
+            println!("🧠 Capsule loaded: {}", capsule.name);
+            capsules.push(capsule);
+        }
+        capsules
+    }
+}
+

--- a/src/lumeria_runtime.rs
+++ b/src/lumeria_runtime.rs
@@ -1,0 +1,37 @@
+use crate::lumeria_loader::Capsule;
+
+pub struct LumeriaRuntime {
+    capsules: Vec<Capsule>,
+}
+
+impl LumeriaRuntime {
+    pub fn new(capsules: Vec<Capsule>) -> Self {
+        Self { capsules }
+    }
+
+    pub fn emit(&mut self, signal: &str) {
+        for cap in &self.capsules {
+            for (idx, trig) in cap.triggers.iter().enumerate() {
+                if trig == signal {
+                    if let Some(logic) = cap.logic.get(idx) {
+                        self.execute_logic(logic);
+                    }
+                }
+            }
+        }
+    }
+
+    fn execute_logic(&mut self, logic: &str) {
+        for line in logic.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("> log:") {
+                let msg = rest.trim().trim_matches('"');
+                println!("{}", msg);
+            } else if let Some(rest) = line.strip_prefix("> emit:") {
+                let sig = rest.trim();
+                self.emit(sig);
+            }
+        }
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,13 @@
+mod lumeria_loader;
+mod lumeria_runtime;
+
+use lumeria_loader::CapsuleLoader;
+use lumeria_runtime::LumeriaRuntime;
+
+fn main() {
+    let loader = CapsuleLoader::new("core0.lore");
+    let capsules = loader.load_capsules();
+    let mut runtime = LumeriaRuntime::new(capsules);
+    runtime.emit("boot.capsuleLoader");
+}
+


### PR DESCRIPTION
## Summary
- implement initial `Cargo.toml` for a Rust project
- add a simple capsule loader with debug prints
- add a symbolic runtime that executes `log` and `emit`
- provide minimal `main.rs` booting from `core0.lore`
- include an example capsule in `core0.lore`

## Testing
- `cargo build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871abb680748331afd9bde7d258a6d8