### PR TITLE
Add boot assembly capsule

### DIFF
--- a/core0.boot.assembly.lore
+++ b/core0.boot.assembly.lore
@@ -1,6 +1,7 @@
 [capsule assembly.boot]
 
 [trigger boot.assembly /]
+[trigger boot.assembly.recurse /]
 
 [memory ctx.bootDepth /]
 
@@ -20,7 +21,7 @@
   > default: ctx.bootDepth = 0
   > memory.set: ctx.bootDepth = {{ ctx.bootDepth + 1 }}
   [condition continue.recursion]
-    check: ctx.bootDepth < 2
+    check: ctx.bootDepth < 100
     then:
       > emit: boot.assembly
   [/condition continue.recursion]

--- a/core0.boot.assembly.lore
+++ b/core0.boot.assembly.lore
@@ -2,16 +2,29 @@
 
 [trigger boot.assembly /]
 
+[memory ctx.bootDepth /]
+
 [logic assembly.bootSequence]
   > log: "🚀 [assembly] Starting core boot assembly"
   > emit: boot.capsuleLoader
   > emit: runtime.boot
   > emit: kernel.boot
   > emit: boot.start
-[/logic assembly.bootSequence]
-
+  > emit: boot.assembly.recurse
 [when boot.assembly]
   > emit: assembly.bootSequence
+[/logic assembly.bootSequence]
 [/when boot.assembly]
+
+[logic boot.assembly.recurse]
+  > default: ctx.bootDepth = 0
+  > memory.set: ctx.bootDepth = {{ ctx.bootDepth + 1 }}
+  [condition continue.recursion]
+    check: ctx.bootDepth < 2
+    then:
+      > emit: boot.assembly
+  [/condition continue.recursion]
+  > memory.set: ctx.bootDepth = {{ ctx.bootDepth - 1 }}
+[/logic boot.assembly.recurse]
 
 [/capsule assembly.boot]

--- a/core0.boot.assembly.lore
+++ b/core0.boot.assembly.lore
@@ -2,16 +2,16 @@
 
 [trigger boot.assembly /]
 
-[logic boot.assembly]
+[logic assembly.bootSequence]
   > log: "🚀 [assembly] Starting core boot assembly"
   > emit: boot.capsuleLoader
   > emit: runtime.boot
   > emit: kernel.boot
   > emit: boot.start
-[/logic boot.assembly]
+[/logic assembly.bootSequence]
 
 [when boot.assembly]
-  > emit: boot.assembly
+  > emit: assembly.bootSequence
 [/when boot.assembly]
 
 [/capsule assembly.boot]

--- a/core0.boot.assembly.lore
+++ b/core0.boot.assembly.lore
@@ -1,0 +1,17 @@
+[capsule assembly.boot]
+
+[trigger boot.assembly /]
+
+[logic boot.assembly]
+  > log: "🚀 [assembly] Starting core boot assembly"
+  > emit: boot.capsuleLoader
+  > emit: runtime.boot
+  > emit: kernel.boot
+  > emit: boot.start
+[/logic boot.assembly]
+
+[when boot.assembly]
+  > emit: boot.assembly
+[/when boot.assembly]
+
+[/capsule assembly.boot]

--- a/core0.boot.assembly.lore
+++ b/core0.boot.assembly.lore
@@ -12,9 +12,10 @@
   > emit: kernel.boot
   > emit: boot.start
   > emit: boot.assembly.recurse
+[/logic assembly.bootSequence]
+
 [when boot.assembly]
   > emit: assembly.bootSequence
-[/logic assembly.bootSequence]
 [/when boot.assembly]
 
 [logic boot.assembly.recurse]

--- a/src/lumeria_runtime.rs
+++ b/src/lumeria_runtime.rs
@@ -1,12 +1,14 @@
 use crate::lumeria_loader::Capsule;
+use std::collections::HashMap;
 
 pub struct LumeriaRuntime {
     capsules: Vec<Capsule>,
+    memory: HashMap<String, i64>,
 }
 
 impl LumeriaRuntime {
     pub fn new(capsules: Vec<Capsule>) -> Self {
-        Self { capsules }
+        Self { capsules, memory: HashMap::new() }
     }
 
     pub fn emit(&mut self, signal: &str) {
@@ -22,15 +24,88 @@ impl LumeriaRuntime {
     }
 
     fn execute_logic(&mut self, logic: &str) {
-        for line in logic.lines() {
-            let line = line.trim();
+        let mut lines = logic.lines().peekable();
+        while let Some(raw) = lines.next() {
+            let line = raw.trim();
             if let Some(rest) = line.strip_prefix("> log:") {
                 let msg = rest.trim().trim_matches('"');
                 println!("{}", msg);
             } else if let Some(rest) = line.strip_prefix("> emit:") {
                 let sig = rest.trim();
                 self.emit(sig);
+            } else if let Some(rest) = line.strip_prefix("> default:") {
+                if let Some((k,v)) = self.parse_assignment(rest) {
+                    self.memory.entry(k).or_insert(v);
+                }
+            } else if let Some(rest) = line.strip_prefix("> memory.set:") {
+                if let Some((k,v)) = self.parse_assignment(rest) {
+                    self.memory.insert(k, v);
+                }
+            } else if line.starts_with("[condition") {
+                if let Some(end_idx) = line.find(']') {
+                    let name = line[10..end_idx].trim();
+                    let check_line = lines.next().unwrap_or("");
+                    let cond = check_line.trim().strip_prefix("check:").unwrap_or("").trim();
+                    let then_line = lines.next().unwrap_or("");
+                    if !then_line.trim().starts_with("then:") { continue; }
+                    let mut block = String::new();
+                    while let Some(next) = lines.next() {
+                        if next.trim() == format!("[/condition {}]", name) { break; }
+                        block.push_str(next);
+                        block.push('\n');
+                    }
+                    if self.evaluate_condition(cond) {
+                        self.execute_logic(&block);
+                    }
+                }
             }
+        }
+    }
+
+    fn parse_assignment(&mut self, raw: &str) -> Option<(String,i64)> {
+        let mut parts = raw.trim().splitn(2,'=');
+        let key = parts.next()?.trim().to_string();
+        let val_expr = parts.next()?.trim();
+        let value = self.parse_value(val_expr);
+        Some((key,value))
+    }
+
+    fn parse_value(&self, expr: &str) -> i64 {
+        let expr = expr.trim();
+        if expr.starts_with("{{") && expr.ends_with("}}"){ 
+            let inner = expr.trim_start_matches("{{").trim_end_matches("}}").trim();
+            let mut tokens = inner.split_whitespace();
+            if let (Some(var), Some(op), Some(num)) = (tokens.next(), tokens.next(), tokens.next()) {
+                let val: i64 = num.parse().unwrap_or(0);
+                let base = *self.memory.get(var).unwrap_or(&0);
+                return match op {
+                    "+" => base + val,
+                    "-" => base - val,
+                    _ => base,
+                };
+            }
+            0
+        } else {
+            expr.parse().unwrap_or(0)
+        }
+    }
+
+    fn evaluate_condition(&self, cond: &str) -> bool {
+        let mut tokens = cond.split_whitespace();
+        if let (Some(var), Some(op), Some(num_str)) = (tokens.next(), tokens.next(), tokens.next()) {
+            let left = *self.memory.get(var).unwrap_or(&0);
+            let right: i64 = num_str.parse().unwrap_or(0);
+            match op {
+                "<" => left < right,
+                "<=" => left <= right,
+                ">" => left > right,
+                ">=" => left >= right,
+                "==" => left == right,
+                "!=" => left != right,
+                _ => false,
+            }
+        } else {
+            false
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,14 @@ use lumeria_loader::CapsuleLoader;
 use lumeria_runtime::LumeriaRuntime;
 
 fn main() {
-    let loader = CapsuleLoader::new("core0.lore");
-    let capsules = loader.load_capsules();
+    let loader_primary = CapsuleLoader::new("core0.lore");
+    let mut capsules = loader_primary.load_capsules();
+
+    // Load additional boot assembly capsules
+    let loader_boot = CapsuleLoader::new("core0.boot.assembly.lore");
+    capsules.extend(loader_boot.load_capsules());
+
     let mut runtime = LumeriaRuntime::new(capsules);
-    runtime.emit("boot.capsuleLoader");
+    runtime.emit("boot.assembly");
 }
 


### PR DESCRIPTION
## Summary
- add `core0.boot.assembly.lore` to manage early boot sequence
- load the new capsule in `main.rs` so `boot.assembly` starts the loader

## Testing
- `cargo run --offline` *(fails: no matching package named `regex` found)*
- `cargo run` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6872aa465f9c83319e3a6150f85c1a1d